### PR TITLE
プロトタイプ情報削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_user, only: :destroy
 
   def index
     @prototypes = Prototype.all
@@ -40,5 +41,12 @@ class PrototypesController < ApplicationController
     return if user_signed_in?
 
     redirect_to action: :index
+  end
+
+  def move_to_user
+    @prototype = Prototype.find(params[:id])
+    if current_user.id != @prototype.user.id
+    redirect_to root_path
+    end
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -24,6 +24,12 @@ class PrototypesController < ApplicationController
     @comments = @prototype.comments.includes(:user)
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+    redirect_to root_path
+  end
+
   private
 
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,12 +5,12 @@
         <%= "プロトタイプのタイトル"%>
       </p>
       <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete } , class: :prototype__btn %>
         </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <% end %>
       <div class="prototype__image">
         <%= image_tag @prototype.image %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create, :show] do
+  resources :prototypes, only: [:index, :new, :create, :show, :destroy] do
     resources :comments, only: :create
   end
   resources :users


### PR DESCRIPTION
# What
削除機能を実装
# Why
削除機能を実装するため

ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
https://gyazo.com/ba7649e4e0d9314f8692efef214f36cb

念の為ログアウト時の詳細画面の表示も載せときます（編集・削除ボタンがない状態）
https://gyazo.com/a65120b52f8e35d28f92bc6bfff6668a